### PR TITLE
Feature/5 add date

### DIFF
--- a/js/likes.js
+++ b/js/likes.js
@@ -59,6 +59,7 @@ if (typeof PComm === "undefined") {
                 var objectType = $(this).data('type');
                 var target = $(this);
                 var like = (PComm.likes.hasLike(postId)) ? -1 : 1;
+
                 $.ajax({
                     type: "POST",
                     url: likeUrl,
@@ -76,9 +77,11 @@ if (typeof PComm === "undefined") {
                         $('.status', $(self)).removeClass('fa-heart')
                             .removeClass('fa-heart-o')
                             .addClass(faClass);
-                        $('.likes-text', $(self)).text(likesText);
-
-                    }
+                        $('.like-text', $(self)).text(likesText);
+                        const date = new Date;
+                        const dateFormatted = (date.getMonth() + 1) + '/' + date.getDate() + '/' + date.getFullYear() + ' ' + date.getHours() + ':' + date.getMinutes();
+                        like == 1 && $('.like-date').html(dateFormatted)
+                    },
                 });
             }
         }

--- a/pcomm-likes.php
+++ b/pcomm-likes.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
 Plugin Name: Partnercomm Likes
 Description: Add likes to posts
@@ -11,71 +12,98 @@ Usage, hiding text and changing to thumbs up icon:
 do_shortcode('[pclikes post=' . $post->ID . ' show_text=false fa_icon="thumbs-up"]');
 */
 
-class PCommLikes {
+class PCommLikes
+{
 
     protected $prefix = "pc_";
 
-    public function __construct() {
-        add_action( 'init', array( $this, 'init' ) );
+    public function __construct()
+    {
+        add_action('init', array($this, 'init'));
         add_action('wp_ajax_nopriv_like', array($this, 'like'));
         add_action('wp_ajax_like', array($this, 'like'));
     }
 
-    public function init() {
+    public function init()
+    {
         add_shortcode('pclikes', [$this, 'getLikes']);
         wp_enqueue_script('like-js', plugins_url('js/likes.js', __FILE__), array('jquery'), '', true);
         wp_localize_script('like-js', 'like_ajax', array(
                 'ajaxurl' => admin_url('admin-ajax.php'),
-                'domain'  => $_SERVER['SERVER_NAME']
+                'domain' => $_SERVER['SERVER_NAME']
             )
         );
     }
 
-    public function like() {
+    public function like()
+    {
         $post_id = $_POST['post'];
-        $like = (int) $_POST['like'];
+        $like = (int)$_POST['like'];
         $type = $_POST['type'];
+        $date = new DateTime();
+        $meta_key = $this->prefix . 'like_count';
+        $meta_value = [
+            'count' => 0,
+            'date' => $date
+        ];
 
-        if($type == 'comment') {
-            $current_likes = (int) get_comment_meta($post_id, $this->prefix.'like_count', true);
-            $new_likes = $current_likes + $like;
-
-            //set the post meta to the new values
-            update_comment_meta($post_id, $this->prefix.'like_count', $new_likes);
-        } else {
-            $current_likes = (int) get_post_meta($post_id, $this->prefix.'like_count', true);
-            $new_likes = $current_likes + $like;
-
-            //set the post meta to the new values
-            update_post_meta($post_id, $this->prefix.'like_count', $new_likes);
+        switch ($type) {
+            case 'comment':
+                $current_likes = get_comment_meta($post_id, $meta_key, true);
+                $current_likes = (int)$current_likes['count'];
+                $meta_value['count'] = $current_likes + $like;
+                update_post_meta($post_id, $meta_key, $meta_value);
+                break;
+            default:
+                $current_likes = get_post_meta($post_id, $meta_key, true);
+                $current_likes = (int)$current_likes['count'];
+                $meta_value['count'] = $current_likes + $like;
+                update_post_meta($post_id, $meta_key, $meta_value);
+                break;
         }
-
-
-        $result = $new_likes;
+        $result = $meta_value['count'];
         echo ($result > -1) ? $result : 0;
         die();
     }
 
-    public function getLikes($atts) {
+    public function getLikes($atts)
+    {
         $atts = shortcode_atts([
-            'post'=>0,
-            'show_text' => true,
-            'fa_icon' => 'heart'
+            'post' => 0,
+            'show_text' => false, // hide by default
+            'show_date' => false, // hide by default
+            'fa_icon' => 'heart',
         ], $atts);
-        $post_id = (int) $atts['post'];
-        if($post_id == 0) {
+        $post_id = (int)$atts['post'];
+
+        if ($post_id == 0) {
             echo 'Error Loading Likes';
         }
 
         $icon = $atts['fa_icon'];
-        $current_likes = (int) get_post_meta($post_id, $this->prefix.'like_count', true);
+
+        $show_date = '';
+
+        $meta_key = $this->prefix . 'like_count';
+        $meta_value = get_post_meta($post_id, $meta_key, true);
+        if (is_array($meta_value)) {
+            $current_likes = (int)$meta_value['count'];
+            $like_date = $meta_value['date'];
+            if ($like_date && $atts['show_date'] === 'true')
+                $show_date = '<span class="like-date">' . $like_date->format('m/d/Y h:i') . '</span>';
+        } else {
+            $current_likes = (int)$meta_value;
+        }
+
         $like_text = $current_likes === 1 ? 'like' : 'likes';
-        $show_text = $atts['show_text'] === 1 ? '<span class="like-text">' . $like_text . '</span>' : '';
+
+        $show_text = $atts['show_text'] === 'true' ? '<span class="like-text">' . $like_text . '</span>' : '';
 
         echo "<a data-post-id='{$post_id}' class='pcLikes' href='#'>
                 <i class='status fa fa-{$icon}' aria-hidden='true'></i>
                 <span class='count'>{$current_likes}</span> 
                 {$show_text}
+                {$show_date}
               </a>";
     }
 }


### PR DESCRIPTION
There is a couple of issues to address still. Primarily the date. We're initially rendering the date on the server, like most WP sites. But this doesn't take into account the visitors time zone. To do this 100% right, we'll need to store the date in UTC, and have the browser handle all of the date rendering. However, I'm going to punt this over since I'm not sure how far you want to go with that.

Fixed one front end bug, one php bug - both related to the like text. Set the like text to default to off by design (it was by accident before).

I'm willing to chat about any or all of this if you have any questions.